### PR TITLE
fix self referencing in pack operation

### DIFF
--- a/PngMagic/PngMagic/PackOperation.cs
+++ b/PngMagic/PngMagic/PackOperation.cs
@@ -8,7 +8,7 @@ public static class PackOperation
     const int DATA_BUFFER_SIZE = 1028;
 
     public static void Start(string containerPng, Stream outputStream, params Stream[] payloadStreams) =>
-        Start(containerPng, outputStream, payloadStreams);
+        Start(containerPng, outputStream, payloadStreams.AsSpan());
 
     public static void Start(string containerPng, Stream outputStream, ReadOnlySpan<Stream> payloadStreams)
     {
@@ -204,7 +204,7 @@ public static class PackOperation
     }
 
     public static void Start(string containerPng, Stream outputStream, params string[] payloadFiles) =>
-        Start(containerPng, outputStream, payloadFiles);
+        Start(containerPng, outputStream, payloadFiles.AsSpan());
 
     public static void Start(string containerPng, Stream outputStream, ReadOnlySpan<string> payloadFiles)
     {


### PR DESCRIPTION
Now properly reroutes into the Span<T> overloads containing the actual logic.